### PR TITLE
Use Stdlib instead of Caml in test1.ml (to build on Debian testing)

### DIFF
--- a/test/test1.ml
+++ b/test/test1.ml
@@ -236,8 +236,8 @@ let %test_unit "sel.event.now.order0" =
   let e2 = now ~priority:1 2 in
   let e3 = now ~priority:2 3 in
   let e4 = now ~priority:2 4 in
-  let q = Caml.Queue.create () in
-  Caml.Queue.add 0 q;
+  let q = Stdlib.Queue.create () in
+  Stdlib.Queue.add 0 q;
   let x = On.queue ~priority:1 q (fun x -> x) in
   let todo = Todo.add Todo.empty [x;e1;e3] in
   let todo = Todo.add todo [e2;e4] in
@@ -255,8 +255,8 @@ let %test_unit "sel.event.now.order1" =
   let e2 = now ~priority:1 2 in
   let e3 = now ~priority:2 3 in
   let e4 = now ~priority:2 4 in
-  let q = Caml.Queue.create () in
-  Caml.Queue.add 0 q;
+  let q = Stdlib.Queue.create () in
+  Stdlib.Queue.add 0 q;
   let x = On.queue ~priority:1 q (fun x -> x) in
   let todo = Todo.add Todo.empty [e1;x;e3] in
   let todo = Todo.add todo [e2;e4] in


### PR DESCRIPTION
I tried building this repo with dependencies from Debian testing and got the error below. I was able to get this library to build by doing `find test lib -name '*.ml' | xargs sed -i 's/Caml.Queue/Stdlib.Queue/g'`.

```
Alert deprecated: module Base.Caml
[since 2023-01] use Stdlib instead of Caml

File "test/test1.ml", line 239, characters 10-27:
239 |   let q = Caml.Queue.create () in
                ^^^^^^^^^^^^^^^^^
Error: Unbound module Caml.Queue
```

<details>
```
andreser@andreser-test:~/sel.0.4.0$ dune build --display=verbose
Shared cache: disabled
Shared cache location: /home/andreser/.cache/dune/db
Workspace root: /home/andreser/sel.0.4.0
Auto-detected concurrency: 30
Dune context:
 { name = "default"
 ; kind = "default"
 ; profile = Dev
 ; merlin = true
 ; fdo_target_exe = None
 ; build_dir = In_build_dir "default"
 ; instrument_with = []
 }
Actual targets:
- alias @@default
Running[1]: (cd _build/default && /usr/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -warn-error -A -g -bin-annot -bin-annot-occurrences -I test/.sel_tests.objs/byte -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/base -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/base/base_internalhash_types -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/base/shadow_stdlib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/jane-street-headers -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ocaml_intrinsics_kernel -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_assert/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_compare/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_deriving/runtime -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_enumerate/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_hash/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_here/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_inline_test/config -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_inline_test/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_sexp_conv/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/sexplib0 -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/stdio -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/str -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/time_now -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/unix -I lib/.sel.objs/public_cmi -no-alias-deps -opaque -open Sel_tests -o test/.sel_tests.objs/byte/sel_tests__Test1.cmo -c -impl test/test1.pp.ml)
Command [1] exited with code 2:     
$ (cd _build/default && /usr/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -short-paths -keep-locs -warn-error -A -g -bin-annot -bin-annot-occurrences -I test/.sel_tests.objs/byte -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/base -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/base/base_internalhash_types -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/base/shadow_stdlib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/jane-street-headers -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ocaml_intrinsics_kernel -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_assert/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_compare/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_deriving/runtime -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_enumerate/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_hash/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_here/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_inline_test/config -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_inline_test/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/ppx_sexp_conv/runtime-lib -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/sexplib0 -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/stdio -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/str -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/time_now -I /usr/lib/x86_64-linux-gnu/ocaml/5.2.0/unix -I lib/.sel.objs/public_cmi -no-alias-deps -opaque -open Sel_tests -o test/.sel_tests.objs/byte/sel_tests__Test1.cmo -c -impl test/test1.pp.ml)
File "test/test1.ml", line 239, characters 10-27:
239 |   let q = Caml.Queue.create () in
                ^^^^^^^^^^^^^^^^^
Alert deprecated: module Base.Caml
[since 2023-01] use Stdlib instead of Caml

File "test/test1.ml", line 239, characters 10-27:
239 |   let q = Caml.Queue.create () in
                ^^^^^^^^^^^^^^^^^
Error: Unbound module Caml.Queue
```
</details>

